### PR TITLE
Feat/agentic control plane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!frontend/src/lib/  # Allow frontend/src/lib/ directory
 lib64/
 parts/
 sdist/

--- a/END-TO-END-TEST-PLAN.md
+++ b/END-TO-END-TEST-PLAN.md
@@ -1,0 +1,196 @@
+# End-to-End Test Plan: Repo A → Repo B → Repo C
+
+## Current State
+
+- ✅ **Repo A (leadscore)**: Python router with executor adapter support
+- ✅ **Repo B (governance-hub)**: Policy authority (optional for now)
+- ✅ **Repo C (key-vault-executor)**: Key vault + executor
+- ⚠️ **Leadscoring pack**: Uses Django models directly (doesn't use Repo C)
+
+## Test Strategy
+
+### Phase 1: Test Repo A Alone (No Repo C/B)
+**Purpose:** Verify basic Repo A functionality
+
+```bash
+# Test meta actions
+curl -X POST https://YOUR_RAILWAY_DOMAIN.railway.app/api/manage \
+  -H "X-API-Key: YOUR_DRF_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"action": "meta.actions"}'
+
+# Test leadscoring action (uses Django, not Repo C)
+curl -X POST https://YOUR_RAILWAY_DOMAIN.railway.app/api/manage \
+  -H "X-API-Key: YOUR_DRF_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"action": "domain.leadscoring.models.list"}'
+```
+
+**Expected:** Both should work (no Repo C/B involved)
+
+---
+
+### Phase 2: Test Repo A → Repo C (No Repo B)
+**Purpose:** Verify executor adapter works
+
+**Option A: Use existing CIQ action (if tenant configured)**
+
+If you have a tenant configured in Repo C with CIQ integration:
+
+```bash
+curl -X POST https://YOUR_RAILWAY_DOMAIN.railway.app/api/manage \
+  -H "X-API-Key: YOUR_DRF_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "action": "test.ciq.publishers.list",
+    "params": {}
+  }'
+```
+
+**Option B: Add a test action to leadscoring pack**
+
+Add this to `backend/control_plane/packs.py`:
+
+```python
+def handle_test_repo_c(params, ctx):
+    """Test action that calls Repo C"""
+    executor = ctx.get('executor')
+    if not executor:
+        raise ValueError("Executor not configured")
+    
+    tenant_id = ctx['tenant_id']
+    
+    # Call Repo C via executor
+    result = executor.execute(
+        endpoint=f"/api/tenants/{tenant_id}/ciq/publishers.list",
+        params={},
+        tenant_id=tenant_id,
+        trace={
+            'kernel_id': ctx.get('bindings', {}).get('kernelId', 'leadscore-kernel'),
+            'actor_id': ctx.get('api_key_id'),
+        }
+    )
+    
+    return {
+        "data": {
+            "message": "Successfully called Repo C",
+            "repo_c_response": result.data,
+            "resource_type": result.resource_type,
+        }
+    }
+
+# Add to actions list:
+ActionDef(
+    name="test.repo_c.ciq.publishers.list",
+    scope="manage.read",
+    description="Test action to verify Repo C integration",
+    params_schema={"type": "object", "properties": {}},
+    supports_dry_run=False,
+),
+
+# Add to handlers:
+"test.repo_c.ciq.publishers.list": handle_test_repo_c,
+```
+
+**Prerequisites:**
+1. Tenant configured in Repo C `tenant_integrations` table
+2. CIQ secret configured in Supabase Vault
+3. Service key generated and in Railway env vars
+
+---
+
+### Phase 3: Test Repo A → Repo B → Repo C (Full Flow)
+**Purpose:** Verify governance + execution flow
+
+**Steps:**
+1. Register kernel in Repo B via `/heartbeat`
+2. Create a policy in Repo B (optional - default is allow)
+3. Call a write action that triggers authorization
+
+**Test:**
+```bash
+# This would need a write action that:
+# 1. Calls Repo B /authorize
+# 2. If allowed, calls Repo C /execute
+# 3. Returns result
+
+curl -X POST https://YOUR_RAILWAY_DOMAIN.railway.app/api/manage \
+  -H "X-API-Key: YOUR_DRF_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "action": "test.repo_c.ciq.campaigns.create",
+    "params": {"name": "Test Campaign"}
+  }'
+```
+
+**Prerequisites:**
+1. All Phase 2 prerequisites
+2. Repo B configured (`GOVERNANCE_HUB_URL`, `ACP_KERNEL_KEY`)
+3. Kernel registered in Repo B
+4. Control plane adapter implemented in Python (not done yet)
+
+---
+
+## Recommended Approach
+
+### Quick Test (5 minutes)
+**Just test Repo A works:**
+- Run Phase 1 tests
+- Verify existing leadscoring actions work
+- This confirms Repo A infrastructure is solid
+
+### Full Integration Test (30 minutes)
+**Test Repo A → Repo C:**
+1. Add test action to leadscoring pack (see Phase 2, Option B)
+2. Configure tenant in Repo C
+3. Test the action
+4. Verify it calls Repo C successfully
+
+### Complete Flow Test (1 hour)
+**Test Repo A → Repo B → Repo C:**
+1. Implement control plane adapter for Python
+2. Register kernel in Repo B
+3. Test write action with governance
+
+---
+
+## What I Recommend
+
+**Start with Phase 1** - Just have your agent try the existing leadscoring actions. This will:
+- ✅ Verify Repo A is working
+- ✅ Confirm environment variables are set correctly
+- ✅ Test the basic infrastructure
+
+**Then add Phase 2** - Add a simple test action that calls Repo C to verify:
+- ✅ Executor adapter works
+- ✅ Repo C authentication works
+- ✅ End-to-end execution flow
+
+**Phase 3 can wait** - Full governance flow requires implementing the control plane adapter in Python, which is more complex.
+
+---
+
+## Quick Test Script
+
+Save this as `test-repo-a.sh`:
+
+```bash
+#!/bin/bash
+
+RAILWAY_DOMAIN="your-railway-domain.railway.app"
+API_KEY="your-drf-token"
+
+echo "Testing Repo A - Meta Actions..."
+curl -X POST "https://${RAILWAY_DOMAIN}/api/manage" \
+  -H "X-API-Key: ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"action": "meta.actions"}' | jq .
+
+echo -e "\n\nTesting Repo A - Leadscoring List..."
+curl -X POST "https://${RAILWAY_DOMAIN}/api/manage" \
+  -H "X-API-Key: ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"action": "domain.leadscoring.models.list"}' | jq .
+```
+
+Run: `chmod +x test-repo-a.sh && ./test-repo-a.sh`

--- a/REPO-B-INTEGRATION-STATUS.md
+++ b/REPO-B-INTEGRATION-STATUS.md
@@ -1,0 +1,129 @@
+# Repo B Integration Status
+
+## ✅ What's Implemented
+
+### 1. Control Plane Adapter (`control_plane_adapter.py`)
+- ✅ `HttpControlPlaneAdapter` - Calls Repo B `/authorize` endpoint
+- ✅ `heartbeat()` method - Sends heartbeat to Repo B on startup
+- ✅ Authorization request/response handling
+
+### 2. Router Updates (`acp/router.py`)
+- ✅ Authorization check before write actions (create, update, delete)
+- ✅ Calls Repo B `/authorize` for write actions
+- ✅ Handles `allow`, `deny`, `require_approval` decisions
+- ✅ Fail-closed if Repo B unreachable (for write actions)
+- ✅ Passes `policy_decision_id` to audit logs
+
+### 3. Audit Adapter (`repo_b_audit_adapter.py`)
+- ✅ `RepoBAuditAdapter` - Sends audit events to Repo B `/api/audit/ingest`
+- ✅ Formats events to match Repo B's `AuditEvent` interface
+- ✅ Best-effort (doesn't block requests if it fails)
+
+### 4. Views Updates (`views.py`)
+- ✅ Initializes control plane adapter from env vars
+- ✅ Sends heartbeat on startup
+- ✅ Passes control plane to router
+- ✅ Uses Repo B audit adapter if configured
+
+## 🔄 Flow for Your Test
+
+When agent adds a question to leadscore:
+
+```
+1. Agent → Repo A (/api/manage)
+   ↓
+2. Repo A validates API key (local)
+   ↓
+3. Repo A checks if action is write action (create/update/delete)
+   ↓
+4. [If write] Repo A → Repo B /authorize
+   - Sends: kernel_id, tenant_id, actor, action, request_hash
+   ↓
+5. Repo B evaluates policies → { decision: 'allow' | 'deny' | 'require_approval' }
+   ↓
+6. [If allowed] Repo A executes handler (Django model save)
+   ↓
+7. Repo A → Repo B /api/audit/ingest
+   - Sends: event with policy_decision_id, status, result_meta
+   ↓
+8. Repo B stores audit log
+   ↓
+9. Repo A returns response to agent
+```
+
+## ⚠️ Known Issues
+
+### 1. Repo B Audit Authentication
+The `/api/audit/ingest` endpoint currently expects Supabase auth token, not kernel API key. You may need to:
+- Update Repo B's `audit-ingest` endpoint to accept kernel API keys, OR
+- Use a different authentication method
+
+**Workaround:** The audit adapter will try to send with kernel API key. If Repo B rejects it, events will fail silently (best-effort).
+
+### 2. Kernel ID in Audit Events
+Repo B's audit service currently uses `event.actor.id` for `kernel_id`, which is incorrect. It should extract `kernel_id` from the authenticated kernel context.
+
+**Impact:** Audit events may have wrong `kernel_id` in Repo B database.
+
+### 3. Organization ID
+Repo B's audit-ingest extracts `organization_id` from user metadata. For kernels, you may need to:
+- Include `organization_id` in the audit event, OR
+- Update Repo B to extract it from kernel authentication
+
+## 🧪 Testing Checklist
+
+### Prerequisites
+- [ ] `GOVERNANCE_HUB_URL` set in Railway
+- [ ] `ACP_KERNEL_KEY` set in Railway
+- [ ] Kernel registered in Repo B (via heartbeat or manual SQL)
+- [ ] Policy created in Repo B (optional - default is allow)
+
+### Test Steps
+
+1. **Check Heartbeat on Startup**
+   - Deploy to Railway
+   - Check logs for: `✅ Kernel registered with Repo B: leadscore-kernel`
+   - OR check Repo B `kernels` table for your kernel
+
+2. **Test Write Action (Add Question)**
+   ```bash
+   curl -X POST https://YOUR_RAILWAY_DOMAIN/api/manage \
+     -H "X-API-Key: YOUR_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "action": "domain.leadscoring.models.create",
+       "params": {"question_id": 1, "weight": 1.0}
+     }'
+   ```
+
+3. **Verify in Repo B**
+   - Check `audit_logs` table in Repo B
+   - Should see event with:
+     - `kernel_id` = "leadscore-kernel"
+     - `action` = "domain.leadscoring.models.create"
+     - `status` = "success"
+     - `policy_decision_id` = (if authorization was checked)
+
+## 📝 Notes
+
+- **Heartbeat** is sent on Django app startup (when router is first created)
+- **Authorization** only happens for write actions (create, update, delete)
+- **Audit logging** is best-effort (won't block requests if Repo B is down)
+- **Read actions** (list, get) don't call Repo B (faster, no governance needed)
+
+## 🔧 If Things Don't Work
+
+1. **Heartbeat fails:**
+   - Check `GOVERNANCE_HUB_URL` and `ACP_KERNEL_KEY` are set
+   - Check kernel is registered in Repo B `kernels` table
+   - Check Repo B `/heartbeat` endpoint is accessible
+
+2. **Authorization fails:**
+   - Check Repo B `/authorize` endpoint is accessible
+   - Check kernel API key is valid
+   - Check policies in Repo B allow the action
+
+3. **Audit events not appearing:**
+   - Check Repo B `/api/audit/ingest` endpoint accepts kernel API keys
+   - Check Railway logs for audit errors (they're silent by design)
+   - Verify event format matches Repo B's expected schema

--- a/REPO-C-ENV-SETUP.md
+++ b/REPO-C-ENV-SETUP.md
@@ -1,0 +1,75 @@
+# Repo C Environment Variables Setup (Leadscore)
+
+## Where to Add Environment Variables
+
+**Railway Dashboard → Your Project → Variables Tab**
+
+Add these environment variables:
+
+```bash
+# Repo C (Key Vault Executor) Configuration
+CIA_URL=https://rrzewykkwjdkkccwrjyf.supabase.co
+CIA_ANON_KEY=your-supabase-anon-key-here
+CIA_SERVICE_KEY=cia_service_xxxxx  # Generated service key from Repo C UI
+KERNEL_ID=leadscore-kernel
+
+# Repo B (Governance Hub) Configuration (optional - if using governance)
+GOVERNANCE_HUB_URL=https://your-governance-hub.supabase.co
+ACP_KERNEL_KEY=acp_kernel_xxxxx  # Generated kernel API key from Repo B
+```
+
+## Steps
+
+1. **Go to Railway Dashboard**
+   - https://railway.app
+   - Select your `api-docs-template` project
+
+2. **Navigate to Variables**
+   - Click on your service
+   - Go to "Variables" tab
+
+3. **Add Variables**
+   - Click "New Variable"
+   - Add each variable one by one:
+     - `CIA_URL` = `https://rrzewykkwjdkkccwrjyf.supabase.co`
+     - `CIA_ANON_KEY` = (Get from Repo C Supabase dashboard → Settings → API → anon/public key)
+     - `CIA_SERVICE_KEY` = (Generated from Repo C UI → Service Keys)
+     - `KERNEL_ID` = `leadscore-kernel`
+     - `GOVERNANCE_HUB_URL` = (Your Repo B URL, if using governance)
+     - `ACP_KERNEL_KEY` = (Generated kernel API key from Repo B, if using governance)
+
+4. **Redeploy**
+   - Railway will automatically redeploy when you add variables
+   - Or manually trigger a redeploy from the Deployments tab
+
+## Getting the Values
+
+### CIA_URL
+Already set: `https://rrzewykkwjdkkccwrjyf.supabase.co`
+
+### CIA_ANON_KEY
+1. Go to Repo C Supabase project: https://supabase.com/dashboard/project/rrzewykkwjdkkccwrjyf
+2. Settings → API
+3. Copy the "anon" or "public" key
+
+### CIA_SERVICE_KEY
+1. Go to Repo C UI (or generate via script)
+2. Create a new service key named "leadscore-service-key"
+3. Copy the generated key (shown once)
+
+### KERNEL_ID
+Set to: `leadscore-kernel`
+
+### GOVERNANCE_HUB_URL (Optional - if using Repo B)
+1. Get your Repo B (Governance Hub) Supabase project URL
+2. Format: `https://your-project-id.supabase.co`
+
+### ACP_KERNEL_KEY (Optional - if using Repo B)
+1. Generate a kernel API key (format: `acp_kernel_xxxxx`)
+2. Register the kernel in Repo B via `/heartbeat` endpoint
+3. Compute HMAC hash and store in Repo B `kernels` table
+4. Use the raw key value here (not the hash)
+
+## Next Steps
+
+After adding these variables, you'll need to update the router to use the executor adapter. See `backend/control_plane/views.py` to add the executor.

--- a/backend/control_plane/acp/router.py
+++ b/backend/control_plane/acp/router.py
@@ -56,6 +56,8 @@ def create_manage_router(
     ceilings_adapter: Any,
     bindings: Dict[str, Any],
     packs: List[Pack],
+    executor: Any = None,  # Optional executor adapter (Repo C)
+    control_plane: Any = None,  # Optional control plane adapter (Repo B)
 ) -> Callable[[Dict, Dict], Dict]:
     """
     Returns router: (request, meta) -> response
@@ -230,6 +232,9 @@ def create_manage_router(
                 "dry_run": dry_run,
                 "request_id": request_id,
                 "user": user,
+                "executor": executor,  # Pass executor to handlers
+                "control_plane": control_plane,  # Pass control plane to handlers
+                "bindings": bindings,  # Pass bindings (includes kernelId, integration)
             }
             result = handler(params, ctx)
         except Exception as e:

--- a/backend/control_plane/acp/router.py
+++ b/backend/control_plane/acp/router.py
@@ -202,6 +202,105 @@ def create_manage_router(
                 "code": "VALIDATION_ERROR",
             }
 
+        # Authorization check via Repo B (for write actions)
+        policy_decision_id = None
+        if control_plane and not dry_run and required_scope in ("manage.domain", "manage.write"):
+            # Check if this is a write action (create, update, delete)
+            is_write_action = any(keyword in action.lower() for keyword in ['create', 'update', 'delete', 'cancel'])
+            
+            if is_write_action:
+                try:
+                    from control_plane.control_plane_adapter import AuthorizationRequest
+                    import hashlib
+                    import json
+                    
+                    # Create request hash (simplified - should use canonical JSON)
+                    params_str = json.dumps(params, sort_keys=True)
+                    request_hash = hashlib.sha256(params_str.encode()).hexdigest()
+                    
+                    # Create params_summary (small subset, sanitized)
+                    params_summary = {}
+                    if isinstance(params, dict):
+                        # Only include non-sensitive fields, limit size
+                        for key, value in list(params.items())[:5]:  # Limit to 5 fields
+                            if key.lower() not in ['password', 'secret', 'token', 'key']:
+                                if isinstance(value, (str, int, float, bool)):
+                                    params_summary[key] = str(value)[:100]  # Truncate long values
+                    
+                    auth_request = AuthorizationRequest(
+                        kernel_id=bindings.get('kernelId', 'leadscore-kernel'),
+                        tenant_id=tenant_id,
+                        actor={
+                            'type': 'api_key',
+                            'id': api_key_id or 'unknown',
+                            'api_key_id': api_key_id,
+                        },
+                        action=action,
+                        request_hash=request_hash,
+                        params_summary=params_summary if params_summary else None,
+                    )
+                    
+                    auth_response = control_plane.authorize(auth_request)
+                    policy_decision_id = auth_response.decision_id
+                    
+                    if auth_response.decision == 'deny':
+                        _log_audit({
+                            "tenant_id": tenant_id,
+                            "actor_type": "api_key",
+                            "actor_id": api_key_id or "unknown",
+                            "action": action,
+                            "request_id": request_id,
+                            "result": "denied",
+                            "error_message": auth_response.reason or "Policy denied",
+                            "ip_address": ip_address,
+                            "dry_run": dry_run,
+                        })
+                        return {
+                            "ok": False,
+                            "request_id": request_id,
+                            "error": auth_response.reason or "Action denied by policy",
+                            "code": "SCOPE_DENIED",
+                        }
+                    elif auth_response.decision == 'require_approval':
+                        _log_audit({
+                            "tenant_id": tenant_id,
+                            "actor_type": "api_key",
+                            "actor_id": api_key_id or "unknown",
+                            "action": action,
+                            "request_id": request_id,
+                            "result": "denied",
+                            "error_message": "Action requires approval",
+                            "ip_address": ip_address,
+                            "dry_run": dry_run,
+                        })
+                        return {
+                            "ok": False,
+                            "request_id": request_id,
+                            "error": "Action requires approval",
+                            "code": "REQUIRES_APPROVAL",
+                            "approval_id": auth_response.approval_id,
+                        }
+                    # If 'allow', continue execution
+                except Exception as e:
+                    # If Repo B is unreachable, fail-closed for write actions
+                    _log_audit({
+                        "tenant_id": tenant_id,
+                        "actor_type": "api_key",
+                        "actor_id": api_key_id or "unknown",
+                        "action": action,
+                        "request_id": request_id,
+                        "result": "denied",
+                        "error_message": f"Authorization check failed: {str(e)}",
+                        "ip_address": ip_address,
+                        "dry_run": dry_run,
+                    })
+                    return {
+                        "ok": False,
+                        "request_id": request_id,
+                        "error": f"Authorization check failed: {str(e)}",
+                        "code": "AUTHORIZATION_ERROR",
+                    }
+
         # Idempotency replay (stub: idempotency_adapter would implement)
         if idempotency_key and not dry_run and idempotency_adapter:
             replay = idempotency_adapter.get_replay(tenant_id, action, idempotency_key)
@@ -273,6 +372,7 @@ def create_manage_router(
             "result": "success",
             "ip_address": ip_address,
             "dry_run": dry_run,
+            "policy_decision_id": policy_decision_id,  # Include if authorization was checked
         })
 
         return {

--- a/backend/control_plane/executor_adapter.py
+++ b/backend/control_plane/executor_adapter.py
@@ -1,0 +1,180 @@
+"""
+ExecutorAdapter - Interface for calling external services (Repo C)
+
+This allows packs to delegate execution to external services while
+maintaining governance through the kernel.
+"""
+
+import hashlib
+import json
+import os
+import re
+from typing import Any, Dict, Optional
+
+import requests
+
+
+class ExecutorResponse:
+    """Response from executor adapter"""
+    def __init__(self, data: Any, resource_ids: Optional[list] = None, 
+                 resource_type: Optional[str] = None, count: Optional[int] = None):
+        self.data = data
+        self.resource_ids = resource_ids
+        self.resource_type = resource_type
+        self.count = count
+
+
+class ExecutorAdapter:
+    """Interface for executing actions via external services"""
+    
+    def execute(self, endpoint: str, params: Dict[str, Any], tenant_id: str,
+                trace: Optional[Dict[str, str]] = None) -> ExecutorResponse:
+        """
+        Execute an action via external service
+        
+        Args:
+            endpoint: Endpoint path (e.g., "/api/tenants/{tenantId}/shopify/products.create")
+            params: Action parameters
+            tenant_id: Tenant ID for the request
+            trace: Optional trace information (kernel_id, policy_decision_id, actor_id)
+        
+        Returns:
+            ExecutorResponse with data and metadata
+        """
+        raise NotImplementedError
+
+
+class HttpExecutorAdapter(ExecutorAdapter):
+    """HTTP implementation of ExecutorAdapter - Calls Repo C /api/execute endpoint"""
+    
+    def __init__(self, cia_url: str, cia_service_key: str, 
+                 cia_anon_key: Optional[str] = None, kernel_id: Optional[str] = None):
+        """
+        Initialize HTTP executor adapter
+        
+        Args:
+            cia_url: Repo C base URL (e.g., https://xxx.supabase.co)
+            cia_service_key: CIA_SERVICE_KEY for authentication
+            cia_anon_key: Supabase anon key (required for Supabase Edge Functions)
+            kernel_id: Optional kernel ID for trace
+        """
+        self.cia_url = cia_url.rstrip('/')
+        self.cia_service_key = cia_service_key
+        self.cia_anon_key = cia_anon_key
+        self.kernel_id = kernel_id
+    
+    def _sanitize(self, obj: Any) -> Any:
+        """Remove sensitive fields from object"""
+        if isinstance(obj, dict):
+            sensitive_keys = {'authorization', 'cookie', 'x-api-key', 'token', 
+                            'access_token', 'refresh_token', 'client_secret', 
+                            'api_key', 'password', 'secret'}
+            return {
+                k: '[REDACTED]' if k.lower() in sensitive_keys else self._sanitize(v)
+                for k, v in obj.items()
+            }
+        elif isinstance(obj, list):
+            return [self._sanitize(item) for item in obj]
+        else:
+            return obj
+    
+    def _canonical_json(self, obj: Any) -> str:
+        """Convert object to canonical JSON string (deterministic)"""
+        if obj is None:
+            return 'null'
+        if isinstance(obj, (str, int, float, bool)):
+            return json.dumps(obj, sort_keys=True, separators=(',', ':'))
+        if isinstance(obj, dict):
+            # Sort keys and recursively canonicalize values
+            sorted_items = sorted(obj.items())
+            canonical_dict = {k: json.loads(self._canonical_json(v)) for k, v in sorted_items}
+            return json.dumps(canonical_dict, sort_keys=True, separators=(',', ':'))
+        if isinstance(obj, list):
+            canonical_list = [json.loads(self._canonical_json(item)) for item in obj]
+            return json.dumps(canonical_list, sort_keys=True, separators=(',', ':'))
+        # Fallback to JSON stringify
+        return json.dumps(obj, sort_keys=True, separators=(',', ':'))
+    
+    def _hash_payload(self, payload: str) -> str:
+        """Compute SHA-256 hash of payload"""
+        return hashlib.sha256(payload.encode('utf-8')).hexdigest()
+    
+    def execute(self, endpoint: str, params: Dict[str, Any], tenant_id: str,
+                trace: Optional[Dict[str, str]] = None) -> ExecutorResponse:
+        """
+        Execute an action via Repo C
+        
+        Args:
+            endpoint: Endpoint path (e.g., "/api/tenants/{tenantId}/shopify/products.create")
+            params: Action parameters
+            tenant_id: Tenant ID for the request
+            trace: Optional trace information (kernel_id, policy_decision_id, actor_id)
+        
+        Returns:
+            ExecutorResponse with data and metadata
+        """
+        # Extract integration and action from endpoint
+        # e.g., "/api/tenants/{tenantId}/shopify/products.create" -> integration: "shopify", action: "products.create"
+        match = re.search(r'/(shopify|ciq|leadscore)/(.+)$', endpoint)
+        if not match:
+            raise ValueError(f"Invalid endpoint format: {endpoint}. Expected pattern: /api/tenants/{{tenantId}}/{{integration}}/{{action}}")
+        
+        integration = match.group(1)
+        action = match.group(2)
+        
+        # Create request hash (sanitized, canonical JSON)
+        sanitized_params = self._sanitize(params)
+        canonical_params = self._canonical_json(sanitized_params)
+        request_hash = self._hash_payload(canonical_params)
+        
+        # Call Repo C /api/execute
+        full_url = f"{self.cia_url}/functions/v1/execute"
+        
+        # Build headers - Supabase Edge Functions require apikey header
+        headers = {
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {self.cia_service_key}',
+        }
+        
+        # Add apikey header if provided (required for Supabase Edge Functions)
+        if self.cia_anon_key:
+            headers['apikey'] = self.cia_anon_key
+        
+        # Build request body
+        body = {
+            'tenant_id': tenant_id,
+            'integration': integration,
+            'action': f'{integration}.{action}',  # e.g., "shopify.products.create"
+            'params': params,
+            'request_hash': request_hash,
+            'trace': {
+                'kernel_id': trace.get('kernel_id') if trace else None or self.kernel_id or 'unknown',
+                'policy_decision_id': trace.get('policy_decision_id') if trace else None,
+                'actor_id': trace.get('actor_id') if trace else None,
+            },
+        }
+        
+        # Make request
+        try:
+            response = requests.post(full_url, headers=headers, json=body, timeout=30)
+            response.raise_for_status()
+            result = response.json()
+        except requests.exceptions.RequestException as e:
+            error_msg = str(e)
+            if hasattr(e, 'response') and e.response is not None:
+                try:
+                    error_data = e.response.json()
+                    error_msg = error_data.get('error_message_redacted') or error_data.get('error') or error_msg
+                except:
+                    pass
+            raise Exception(f"CIA executor failed: {error_msg}")
+        
+        # Transform Repo C response to ExecutorResponse format
+        return ExecutorResponse(
+            data=result.get('data'),
+            resource_ids=result.get('result_meta', {}).get('ids_created') or 
+                        ([result.get('result_meta', {}).get('resource_id')] 
+                         if result.get('result_meta', {}).get('resource_id') else None),
+            resource_type=result.get('result_meta', {}).get('resource_type'),
+            count=result.get('result_meta', {}).get('count'),
+        )

--- a/backend/control_plane/repo_b_audit_adapter.py
+++ b/backend/control_plane/repo_b_audit_adapter.py
@@ -1,0 +1,126 @@
+"""
+Audit adapter that sends events to Repo B (Governance Hub)
+
+This replaces the StubAuditAdapter to send audit events to Repo B's /api/audit/ingest endpoint.
+"""
+
+import json
+import os
+import uuid
+from typing import Any, Dict, Optional
+
+import requests
+
+
+class RepoBAuditAdapter:
+    """Audit adapter that sends events to Repo B"""
+    
+    def __init__(self, governance_url: Optional[str] = None, kernel_id: Optional[str] = None,
+                 kernel_api_key: Optional[str] = None):
+        """
+        Initialize audit adapter
+        
+        Args:
+            governance_url: Repo B base URL (optional, will use env var if not provided)
+            kernel_id: Kernel ID (optional, will use env var if not provided)
+            kernel_api_key: Kernel API key for authentication (optional, will use env var if not provided)
+        """
+        self.governance_url = (governance_url or os.environ.get('GOVERNANCE_HUB_URL', '')).rstrip('/')
+        self.kernel_id = kernel_id or os.environ.get('KERNEL_ID', 'leadscore-kernel')
+        self.kernel_api_key = kernel_api_key or os.environ.get('ACP_KERNEL_KEY')
+        self.integration = 'leadscore'
+    
+    def _sanitize(self, obj: Any) -> Any:
+        """Remove sensitive fields from object"""
+        if isinstance(obj, dict):
+            sensitive_keys = {'authorization', 'cookie', 'x-api-key', 'token', 
+                            'access_token', 'refresh_token', 'client_secret', 
+                            'api_key', 'password', 'secret'}
+            return {
+                k: '[REDACTED]' if k.lower() in sensitive_keys else self._sanitize(v)
+                for k, v in obj.items()
+            }
+        elif isinstance(obj, list):
+            return [self._sanitize(item) for item in obj]
+        else:
+            return obj
+    
+    def _canonical_json(self, obj: Any) -> str:
+        """Convert object to canonical JSON string (deterministic)"""
+        if obj is None:
+            return 'null'
+        return json.dumps(obj, sort_keys=True, separators=(',', ':'))
+    
+    def _hash_payload(self, payload: str) -> str:
+        """Compute SHA-256 hash of payload"""
+        import hashlib
+        return hashlib.sha256(payload.encode('utf-8')).hexdigest()
+    
+    def log(self, entry: Dict) -> None:
+        """
+        Send audit event to Repo B
+        
+        This is best-effort - failures should not block the main request
+        """
+        if not self.governance_url:
+            # If Repo B not configured, silently skip (like stub)
+            return
+        
+        try:
+            # Extract pack from action name (e.g., "domain.leadscoring.models.create" -> "leadscoring")
+            action = entry.get('action', '')
+            pack = 'leadscoring' if 'leadscoring' in action else 'meta' if action.startswith('meta.') else 'unknown'
+            
+            # Create request hash if params available
+            request_hash = None
+            if 'params' in entry:
+                sanitized = self._sanitize(entry['params'])
+                canonical = self._canonical_json(sanitized)
+                request_hash = self._hash_payload(canonical)
+            
+            # Build audit event in Repo B format (matches AuditEvent interface)
+            import time
+            audit_event = {
+                'event_id': str(uuid.uuid4()),
+                'event_version': 1,
+                'schema_version': 1,
+                'ts': int(time.time() * 1000),  # Unix timestamp in milliseconds
+                'tenant_id': entry.get('tenant_id', ''),
+                'integration': self.integration,
+                'pack': pack,
+                'action': action,
+                'actor': {
+                    'type': entry.get('actor_type', 'api_key'),
+                    'id': entry.get('actor_id', 'unknown'),
+                    'api_key_id': entry.get('api_key_id'),
+                },
+                'request_hash': request_hash or '',
+                'status': 'success' if entry.get('result') == 'success' else 
+                         'error' if entry.get('result') == 'error' else 
+                         'denied' if entry.get('result') == 'denied' else 'unknown',
+                'policy_decision_id': entry.get('policy_decision_id'),
+                'result_meta': entry.get('result_meta'),  # Optional: what changed
+                'error_code': entry.get('code') if entry.get('result') != 'success' else None,
+                'error_message_redacted': entry.get('error_message', '') if entry.get('result') != 'success' else None,
+            }
+            
+            # Send to Repo B (async, best-effort)
+            url = f"{self.governance_url}/functions/v1/audit-ingest"
+            headers = {
+                'Content-Type': 'application/json',
+            }
+            
+            # Add kernel API key if available (Repo B may need to accept this)
+            if self.kernel_api_key:
+                headers['Authorization'] = f'Bearer {self.kernel_api_key}'
+            
+            # Fire and forget - don't wait for response
+            try:
+                requests.post(url, headers=headers, json=audit_event, timeout=2)
+            except:
+                # Silently fail - audit is best-effort
+                pass
+                
+        except Exception as e:
+            # Log error but don't raise - audit should never block requests
+            print(f"Audit logging error (non-fatal): {e}")

--- a/backend/control_plane/test_repo_c_action.py
+++ b/backend/control_plane/test_repo_c_action.py
@@ -1,0 +1,68 @@
+"""
+Test action to verify Repo C integration
+
+Add this to your leadscoring pack to test the executor adapter.
+"""
+
+from control_plane.acp.types import ActionDef
+
+
+def handle_test_repo_c(params, ctx):
+    """
+    Test action that calls Repo C via executor adapter
+    
+    This verifies:
+    - Executor adapter is configured
+    - Repo C authentication works
+    - End-to-end execution flow
+    """
+    executor = ctx.get('executor')
+    if not executor:
+        raise ValueError("Executor not configured. Check CIA_URL and CIA_SERVICE_KEY environment variables.")
+    
+    tenant_id = ctx['tenant_id']
+    bindings = ctx.get('bindings', {})
+    kernel_id = bindings.get('kernelId', 'leadscore-kernel')
+    
+    # Test: Call Repo C to list CIQ publishers
+    # This requires:
+    # 1. Tenant configured in Repo C tenant_integrations table
+    # 2. CIQ secret in Supabase Vault
+    # 3. Action allowlisted in Repo C
+    
+    try:
+        result = executor.execute(
+            endpoint=f"/api/tenants/{tenant_id}/ciq/publishers.list",
+            params={},
+            tenant_id=tenant_id,
+            trace={
+                'kernel_id': kernel_id,
+                'actor_id': ctx.get('api_key_id'),
+            }
+        )
+        
+        return {
+            "data": {
+                "message": "Successfully called Repo C",
+                "repo_c_status": "success",
+                "repo_c_response": result.data,
+                "resource_type": result.resource_type,
+                "count": result.count,
+            }
+        }
+    except Exception as e:
+        return {
+            "ok": False,
+            "error": f"Repo C call failed: {str(e)}",
+            "code": "REPO_C_ERROR",
+        }
+
+
+# Add this to your leadscoring pack:
+TEST_REPO_C_ACTION = ActionDef(
+    name="test.repo_c.ciq.publishers.list",
+    scope="manage.read",
+    description="Test action to verify Repo C (Key Vault Executor) integration. Requires tenant configured in Repo C.",
+    params_schema={"type": "object", "properties": {}},
+    supports_dry_run=False,
+)

--- a/backend/control_plane/views.py
+++ b/backend/control_plane/views.py
@@ -16,15 +16,35 @@ from control_plane.adapters import (
     StubIdempotencyAdapter,
     StubRateLimitAdapter,
 )
+from control_plane.repo_b_audit_adapter import RepoBAuditAdapter
 from control_plane.executor_adapter import HttpExecutorAdapter
+from control_plane.control_plane_adapter import HttpControlPlaneAdapter
 from control_plane.packs import leadscoring_pack
 
 # Initialize router once
 _router = None
+_control_plane = None
+
+
+def _send_heartbeat():
+    """Send heartbeat to Repo B on startup"""
+    global _control_plane
+    if _control_plane:
+        kernel_id = os.environ.get('KERNEL_ID', 'leadscore-kernel')
+        result = _control_plane.heartbeat(
+            kernel_id=kernel_id,
+            version='1.0.0',
+            packs=['leadscoring'],
+            env=os.environ.get('ENVIRONMENT', 'production')
+        )
+        if result.get('ok'):
+            print(f"✅ Kernel registered with Repo B: {kernel_id}")
+        else:
+            print(f"⚠️ Heartbeat failed: {result.get('error')}")
 
 
 def _get_router():
-    global _router
+    global _router, _control_plane
     if _router is None:
         # Create executor adapter (Repo C) if configured
         executor = None
@@ -38,20 +58,47 @@ def _get_router():
                 kernel_id=os.environ.get('KERNEL_ID', 'leadscore-kernel'),
             )
         
+        # Create control plane adapter (Repo B) if configured
+        governance_url = os.environ.get('GOVERNANCE_HUB_URL')
+        kernel_api_key = os.environ.get('ACP_KERNEL_KEY')
+        if governance_url and kernel_api_key:
+            _control_plane = HttpControlPlaneAdapter(
+                platform_url=governance_url,
+                kernel_api_key=kernel_api_key,
+            )
+            # Send heartbeat on startup
+            try:
+                _send_heartbeat()
+            except Exception as e:
+                print(f"⚠️ Heartbeat error (non-fatal): {e}")
+        
         # Create bindings with kernel_id
         bindings = {
             'kernelId': os.environ.get('KERNEL_ID', 'leadscore-kernel'),
             'integration': 'leadscore',
         }
         
+        # Create audit adapter (send to Repo B if configured, otherwise stub)
+        governance_url = os.environ.get('GOVERNANCE_HUB_URL')
+        kernel_api_key = os.environ.get('ACP_KERNEL_KEY')
+        if governance_url and kernel_api_key:
+            audit_adapter = RepoBAuditAdapter(
+                governance_url=governance_url,
+                kernel_id=bindings['kernelId'],
+                kernel_api_key=kernel_api_key
+            )
+        else:
+            audit_adapter = StubAuditAdapter()
+        
         _router = create_manage_router(
-            audit_adapter=StubAuditAdapter(),
+            audit_adapter=audit_adapter,
             idempotency_adapter=StubIdempotencyAdapter(),
             rate_limit_adapter=StubRateLimitAdapter(),
             ceilings_adapter=StubCeilingsAdapter(),
             bindings=bindings,
             packs=[leadscoring_pack],
             executor=executor,  # Pass executor if available
+            control_plane=_control_plane,  # Pass control plane if available
         )
     return _router
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -16,6 +16,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!src/lib/  # Allow frontend/src/lib/ directory
 lib64/
 parts/
 sdist/

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,52 @@
+/**
+ * API client for backend endpoints
+ */
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
+
+async function request<T>(endpoint: string, options: RequestInit = {}): Promise<{ data: T }> {
+  const url = `${API_BASE_URL}${endpoint}`;
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`API request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return { data };
+}
+
+export const authAPI = {
+  async getProfile() {
+    return request('/v1/auth/profile/');
+  },
+  
+  async login(email: string, password: string) {
+    return request('/v1/auth/login/', {
+      method: 'POST',
+      body: JSON.stringify({ email, password }),
+    });
+  },
+  
+  async logout() {
+    return request('/v1/auth/logout/', {
+      method: 'POST',
+    });
+  },
+};
+
+export const analyticsAPI = {
+  async getLeadSummary() {
+    return request('/v1/analytics/leads/summary/');
+  },
+  
+  async getScoreDistribution() {
+    return request('/v1/analytics/scores/distribution/');
+  },
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Adds an external authorization call (fail-closed) for write actions and new audit shipping to Repo B, which can block or deny previously-allowed operations if misconfigured or unavailable. Also introduces new outbound network dependencies (Repo B/Repo C) on the request path, impacting availability and latency.
> 
> **Overview**
> Adds optional *agentic control plane* integrations: the `/api/manage` router can now (when env vars are set) call Repo B for **pre-execution authorization** on write-like actions and include the resulting `policy_decision_id` in audit logs.
> 
> Introduces new adapters for **Repo B** (`HttpControlPlaneAdapter` with startup `heartbeat` + `RepoBAuditAdapter` shipping best-effort audit events) and **Repo C** (`HttpExecutorAdapter` for `/execute` with request hashing/sanitization), and wires them into `views.py` via environment-driven configuration.
> 
> Frontend switches `src/lib/api.ts` from `axios` to a small `fetch` wrapper (defaulting base URL to `/api`) and expands the client with login/logout and an additional analytics endpoint; `.gitignore` rules are updated to ensure `frontend/src/lib` is not ignored, and new markdown docs capture env setup and E2E test steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecd49d50b3319b9c80ed4fbad7abf10ae6a594ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->